### PR TITLE
use a context manager for configuration (#27)

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -11,13 +11,13 @@ def root_factory(request):
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
-    config = Configurator(root_factory=root_factory, settings=settings)
-    settings = config.get_settings()
     settings['tm.manager_hook'] = 'pyramid_tm.explicit_manager'
-    config.include('pyramid_chameleon')
-    config.include('pyramid_tm')
-    config.include('pyramid_retry')
-    config.include('pyramid_zodbconn')
-    config.add_static_view('static', 'static', cache_max_age=3600)
-    config.scan()
-    return config.make_wsgi_app()
+    with Configurator(settings=settings) as config:
+        config.include('pyramid_chameleon')
+        config.include('pyramid_tm')
+        config.include('pyramid_retry')
+        config.include('pyramid_zodbconn')
+        config.set_root_factory(root_factory)
+        config.add_static_view('static', 'static', cache_max_age=3600)
+        config.scan()
+        return config.make_wsgi_app()


### PR DESCRIPTION
* use a context manager for configuration
- closes #21
- needs to be cherrypicked to 1.9-branch and latest
- need to update Pyramid docs

(cherry picked from commit 13feed4)

* move settings above and out of the context manager
- set the root factory inside the context manager

(cherry picked from commit fc2c126)

(cherry picked from commit be4c0e7)