### PR TITLE
Bump pytest to 3.7.4 to make build pass on Python 2.7 on Windows

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -23,7 +23,7 @@ requires = [
 
 tests_require = [
     'WebTest >= 1.3.1',  # py3 compat
-    'pytest<3.6.0',
+    'pytest>=3.7.4',
     'pytest-cov',
 ]
 


### PR DESCRIPTION
Closes #36