### PR TITLE
Add deprecation warning to the post-gen hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -49,5 +49,14 @@ msg = dedent(
 
     Run your project.
         %(pserve_cmd)s development.ini
+        
+    %(separator)s
+    This cookiecutter has been deprecated in favor of the unified cookiecutter 
+    pyramid-cookiecutter-starter effective with the release of Pyramid 1.10.  
+    pyramid-cookiecutter-starter combines all features of pyramid-cookiecutter-alchemy 
+    and pyramid-cookiecutter-zodb. Please use pyramid-cookiecutter-starter 
+    (https://github.com/pylons/pyramid-cookiecutter-starter) instead of this one. 
+    This cookiecutter may not receive further updates.
+    %(separator)s
     """ % vars)
 print(msg)


### PR DESCRIPTION
As of Pyramid 1.10, pyramid-cookiecutter-zodb has been deprecated in
favor of pyramid-cookiecutter-starter.  Add message to the user to let
them know in the post-gen hook to match the README